### PR TITLE
Ajout d'un tracking de lecture/téléchargement via PodTrac

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ description: >
   Le Ruby Nouveau est un podcast francophone sur la tech en général, le Web et Ruby en particulier.
 baseurl: ""
 url: "https://lerubynouveau.fr"
-media_url: "https://s3-eu-west-1.amazonaws.com/lerubynouveau.media"
+media_url: "http://dts.podtrac.com/redirect.mp3/s3-eu-west-1.amazonaws.com/lerubynouveau.media"
 logo_hd: "logo_le_ruby_nouveau_hd.jpg"
 logo_sd: "madame_rubis_500.png"
 audiofiles_path: "/mp3/"


### PR DESCRIPTION
Les données devraient être plus fiables que celles recueillies via les
logs de S3. Et si ce n'est pas le cas ou si ça ne fonctionne pas, pas
grave, on change l'URL des médias, c'est l'avantage d'héberger le flux
RSS sur une URL fixe qu'on maitrise.