### PR TITLE
Update audio tag width

### DIFF
--- a/css/light.css
+++ b/css/light.css
@@ -21,7 +21,7 @@ a:hover { text-decoration: underline;; }
 .menu a { text-decoration: underline; }
 #transcript, ul { text-align: left; }
 #wrapper { margin: auto; width: 290px; }
-#audio { margin: 1em 0; padding: 0; }
+#audio { margin: 1em 0; padding: 0; width: 100%; }
 #playlist { margin: 0 0 1em 0; padding: 0; }
 #playlist li { margin-left: 0.5em }
 #playlist li.active a { background-color: #9B5725; color: #F8E3D1 }


### PR DESCRIPTION
Set audio tag width to 100% for easier seeking.

Before:
<img width="647" alt="screen shot 2017-09-17 at 18 28 17" src="https://user-images.githubusercontent.com/445045/30525532-504c9c52-9bd6-11e7-8f61-25d70de6d1ba.png">

After:
<img width="654" alt="screen shot 2017-09-17 at 18 28 26" src="https://user-images.githubusercontent.com/445045/30525534-56596e22-9bd6-11e7-99a4-6a3dda00c6cd.png">
